### PR TITLE
Added a cmake build script and fixed errors when compiling with GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Build script for GQ written by Henri Hyyryläinen
+# This is meant to be used within a cmake project
+cmake_minimum_required(VERSION 3.0)
+
+if(UNIX)
+  
+  # C++14
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wl,--no-undefined -Wl,--no-allow-shlib-undefined")
+  
+endif(UNIX)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GUMBO REQUIRED gumbo)
+
+include_directories(${GUMBO_INCLUDE_DIRS})
+link_directories(${GUMBO_LIBRARY_DIRS})
+
+add_library(GQ SHARED
+
+  src/AttributeSelector.cpp
+  src/AttributeSelector.hpp
+  src/BinarySelector.cpp
+  src/BinarySelector.hpp
+  src/Document.cpp
+  src/Document.hpp
+  src/Node.cpp
+  src/Node.hpp
+  src/NodeMutationCollection.cpp
+  src/NodeMutationCollection.hpp
+  src/Parser.cpp 
+  src/Parser.hpp 
+  src/Selection.cpp 
+  src/Selection.hpp 
+  src/Selector.cpp 
+  src/Selector.hpp 
+  src/Serializer.cpp 
+  src/Serializer.hpp 
+  src/SpecialTraits.cpp 
+  src/SpecialTraits.hpp 
+  src/StrRefHash.hpp 
+  src/TextSelector.cpp
+  src/TextSelector.hpp
+  src/TreeMap.cpp
+  src/TreeMap.hpp
+  src/UnarySelector.cpp
+  src/UnarySelector.hpp
+  src/Util.cpp
+  src/Util.hpp
+  )
+
+target_link_libraries(GQ ${GUMBO_LIBRARIES})
+
+
+
+  

--- a/src/AttributeSelector.cpp
+++ b/src/AttributeSelector.cpp
@@ -133,7 +133,7 @@ namespace gq
 
 				if (attributeValue.size() == 0)
 				{
-					return false;
+					return nullptr;
 				}
 
 				// Just do a search
@@ -156,7 +156,7 @@ namespace gq
 
 				if (oneSize == 0 || oneSize != twoSize)
 				{
-					return false;
+					return nullptr;
 				}
 
 				if (oneSize >= 4)
@@ -180,7 +180,7 @@ namespace gq
 					}
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -192,7 +192,7 @@ namespace gq
 
 				if (attributeValue.size() == 0 || attributeValue.size() <= subSize)
 				{					
-					return false;
+					return nullptr;
 				}				
 
 				auto sub = attributeValue.substr(0, subSize);
@@ -223,7 +223,7 @@ namespace gq
 					}
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -236,7 +236,7 @@ namespace gq
 				// If our suffix is greater than the attribute value, we can just move on.
 				if (attributeValue.size() == 0 || subSize >= attributeValue.size())
 				{
-					return false;
+					return nullptr;
 				}
 
 				// Test equality of same-length substring taken from the end.
@@ -268,7 +268,7 @@ namespace gq
 					}
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -280,7 +280,7 @@ namespace gq
 				// return false right away.
 				if (attributeValue.size() == 0 || attributeValue.size() < m_attributeValueRef.size())
 				{
-					return false;
+					return nullptr;
 				}
 
 				if (attributeValue.size() == m_attributeValueRef.size())
@@ -314,7 +314,7 @@ namespace gq
 						}
 					}
 
-					return false;
+					return nullptr;
 				}
 
 				// If there isn't anything that qualifies as whitespace in the CSS selector world,
@@ -323,7 +323,7 @@ namespace gq
 
 				if (anySpacePosition == boost::string_ref::npos)
 				{
-					return false;
+					return nullptr;
 				}				
 				
 				auto firstSpace = attributeValue.find(' ');
@@ -365,7 +365,7 @@ namespace gq
 					firstSpace = attributeValue.find(' ');
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -377,7 +377,7 @@ namespace gq
 				// return false right away.
 				if (attributeValue.size() == 0 || attributeValue.size() < m_attributeValueRef.size())
 				{
-					return false;
+					return nullptr;
 				}
 
 				if (attributeValue.size() == m_attributeValueRef.size())
@@ -411,7 +411,7 @@ namespace gq
 						}
 					}
 
-					return false;
+					return nullptr;
 				}
 
 				// If we didn't find an exact match, then the only hope of a match now is finding
@@ -422,7 +422,7 @@ namespace gq
 
 				if (anyHyphen == boost::string_ref::npos)
 				{
-					return false;
+					return nullptr;
 				}
 
 				// A hyphen was found, so all we have to do is make a case-insensitive match against
@@ -432,7 +432,7 @@ namespace gq
 				if (sub[sub.length() - 1] != '-')
 				{
 					// If the last character in the substring isn't a dash, it can't possibly be a match anyway.
-					return false;
+					return nullptr;
 				}
 
 				sub = attributeValue.substr(0, m_attributeValueRef.size());
@@ -463,12 +463,12 @@ namespace gq
 					}
 				}		
 
-				return false;
+				return nullptr;
 			}
 			break;
 		}
 
-		return false;
+		return nullptr;
 	}
 
 } /* namespace gq */

--- a/src/BinarySelector.cpp
+++ b/src/BinarySelector.cpp
@@ -34,7 +34,7 @@ namespace gq
 {
 
 	BinarySelector::BinarySelector(SelectorOperator op, SharedSelector left, SharedSelector right) :
-		m_operator(op), m_leftHandSide(std::move(left)), m_rightHandSide(std::move(right))
+		m_leftHandSide(std::move(left)), m_rightHandSide(std::move(right)), m_operator(op)
 	{
 		#ifndef NDEBUG
 			assert(m_leftHandSide != nullptr && m_rightHandSide != nullptr && u8"In BinarySelector::BinarySelector(SelectorOperator, SharedSelector, SharedSelector) - Left or right hand selector is nullptr.");
@@ -127,20 +127,20 @@ namespace gq
 				const Node* parent = node->GetParent();
 				if (parent == nullptr)
 				{					
-					return false;
+					return nullptr;
 				}
 
 				if (node->GetIndexWithinParent() == 0)
 				{
 					// Adjacent right hand side must immediately follow the left hand side element.
-					return false;
+					return nullptr;
 				}
 
 				// Can't possibly have an adjacent sibling match without two children.
 				if (parent->GetNumChildren() < 2)
 				{
 					// If there is only 1 child, then we cannot possibly match adjacent nodes.
-					return false;
+					return nullptr;
 				}			
 
 				auto prevSibling = parent->GetChildAt(node->GetIndexWithinParent() - 1);
@@ -162,7 +162,7 @@ namespace gq
 				// Can't be a child without a parent. Boo hoo );
 				if (parent == nullptr)
 				{
-					return false;
+					return nullptr;
 				}
 
 				auto rhsResult = m_rightHandSide->Match(node);
@@ -181,7 +181,7 @@ namespace gq
 				// Can't be a descendant of the void, unless you're Xel'naga.
 				if (parent == nullptr)
 				{
-					return false;
+					return nullptr;
 				}
 
 				auto rhsResult = m_rightHandSide->Match(node);
@@ -199,7 +199,7 @@ namespace gq
 					}
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -212,7 +212,7 @@ namespace gq
 					return rhsResult;
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -221,27 +221,27 @@ namespace gq
 				const Node* parent = node->GetParent();
 				if (parent == nullptr)
 				{
-					return false;
+					return nullptr;
 				}
 
 				if (node->GetIndexWithinParent() == 0)
 				{
 					// Adjacent right hand side must immediately follow the left hand side element.
-					return false;
+					return nullptr;
 				}
 
 				// Can't possibly have an adjacent sibling match without two children.
 				if (parent->GetNumChildren() < 2)
 				{
 					// If there is only 1 child, then we cannot possibly match adjacent nodes.
-					return false;
+					return nullptr;
 				}
 
 				auto rhsResult = m_rightHandSide->Match(node);
 
 				if (rhsResult == false)
 				{
-					return false;
+					return nullptr;
 				}
 
 				auto numChildren = parent->GetNumChildren();
@@ -261,7 +261,7 @@ namespace gq
 					}
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -280,12 +280,12 @@ namespace gq
 					return lshResult;
 				}
 
-				return false;				
+				return nullptr;				
 			}
 			break;
 		}
 
-		return false;
+		return nullptr;
 	}
 
 } /* namespace gq */

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -64,9 +64,9 @@ namespace gq
 
 	Node::Node(const GumboNode* node, const std::string newUniqueId, const size_t indexWithinParent, Node* parent) :
 		m_node(node), 
-		m_nodeUniqueId(std::move(newUniqueId)),
-		m_indexWithinParent(indexWithinParent), 
-		m_parent(parent)
+		m_parent(parent),
+		m_indexWithinParent(indexWithinParent),
+		m_nodeUniqueId(std::move(newUniqueId))
 	{		
 		#ifndef NDEBUG
 			assert(node != nullptr && u8"In Node::Node(const GumboNode*) - Cannot construct a Node around a nullptr.");		
@@ -298,7 +298,7 @@ namespace gq
 		// it's pushed to the collected map.
 		FastAttributeMap collected;
 
-		for (auto& traitsIt = traits.begin(); traitsIt != traits.end(); ++traitsIt)
+		for (auto traitsIt = traits.begin(); traitsIt != traits.end(); ++traitsIt)
 		{
 
 			#ifndef NDEBUG
@@ -397,7 +397,7 @@ namespace gq
 		// made, it's pushed to the collected map.
 		FastAttributeMap collected;
 
-		for (auto& traitsIt = traits.begin(); traitsIt != traits.end(); ++traitsIt)
+		for (auto traitsIt = traits.begin(); traitsIt != traits.end(); ++traitsIt)
 		{
 
 			#ifndef NDEBUG

--- a/src/NodeMutationCollection.cpp
+++ b/src/NodeMutationCollection.cpp
@@ -46,7 +46,7 @@ namespace gq
 
 	const bool NodeMutationCollection::Contains(const GumboNode* rawNode) const
 	{
-		auto& res = m_rawNodes.find(rawNode);
+		const auto& res = m_rawNodes.find(rawNode);
 
 		return res != m_rawNodes.end();
 	}

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -60,7 +60,12 @@ namespace gq
 
 	Parser::Parser()
 	{
-		m_localeEnUS = std::locale(u8"en-US");		
+    #ifdef __linux__
+        // The locale has a '_' instead of '-' on linux
+        m_localeEnUS = std::locale(u8"en_US");
+    #else
+        m_localeEnUS = std::locale(u8"en-US");
+    #endif //__linux__
 	}
 
 	Parser::~Parser()

--- a/src/Selector.cpp
+++ b/src/Selector.cpp
@@ -185,7 +185,7 @@ namespace gq
 					return MatchResult(node);
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -195,7 +195,7 @@ namespace gq
 				if (parent == nullptr)
 				{
 					// Can't be a child without parents. :( Poor node. So sad.
-					return false;
+					return nullptr;
 				}
 
 				int count = 0;
@@ -220,7 +220,7 @@ namespace gq
 
 					if (count > 1)
 					{
-						return false;
+						return nullptr;
 					}
 				}
 
@@ -229,7 +229,7 @@ namespace gq
 					return MatchResult(node);
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -239,7 +239,7 @@ namespace gq
 				if (parent == nullptr)
 				{
 					// Can't be a child without parents. :( Poor node. So sad.
-					return false;
+					return nullptr;
 				}
 
 				// A valid child is a child that is either an element, or a is a node of exactly the
@@ -344,7 +344,7 @@ namespace gq
 					return MatchResult(node);
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -355,12 +355,12 @@ namespace gq
 					return MatchResult(node);
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;		
 		}
 
-		return false;
+		return nullptr;
 	}
 
 	void Selector::MatchAll(const Node* node, std::vector< const Node* >& results) const

--- a/src/TextSelector.cpp
+++ b/src/TextSelector.cpp
@@ -106,7 +106,7 @@ namespace gq
 					return MatchResult(node);
 				}
 				
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -122,7 +122,7 @@ namespace gq
 					return MatchResult(node);
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -134,7 +134,7 @@ namespace gq
 					return MatchResult(node);
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -146,12 +146,12 @@ namespace gq
 					return MatchResult(node);
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 		}
 
-		return false;
+		return nullptr;
 	}
 
 } /* namespace gq */

--- a/src/TreeMap.cpp
+++ b/src/TreeMap.cpp
@@ -57,14 +57,14 @@ namespace gq
 			#endif
 		#endif
 
-		auto& it = m_scopedAttributes.find(scope);
+		const auto& it = m_scopedAttributes.find(scope);
 
 		CollectedAttributesMap* col;
 
 		if (it == m_scopedAttributes.end())
 		{
 			// Insert a new attribute map for the given scope if it doesn't exists already.
-			auto& res = m_scopedAttributes.emplace(std::make_pair(scope, CollectedAttributesMap{}));
+			const auto& res = m_scopedAttributes.emplace(std::make_pair(scope, CollectedAttributesMap{}));
 			col = &res.first->second;
 		}
 		else
@@ -72,13 +72,13 @@ namespace gq
 			col = &it->second;
 		}		
 
-		for (auto& nodeAttrMapIt = nodeAttributeMap.begin(); nodeAttrMapIt != nodeAttributeMap.end(); ++nodeAttrMapIt)
+		for (auto nodeAttrMapIt = nodeAttributeMap.begin(); nodeAttrMapIt != nodeAttributeMap.end(); ++nodeAttrMapIt)
 		{
 			// Need to find the attribute key at this scope. If it doesn't exist, create it and push values. If it
 			// does exist, need to append the node. Must append the node both with the value as the key, and as
 			// "*" as the key (for EXISTS lookups).	
 
-			auto& attr = col->find(nodeAttrMapIt->first);
+			const auto& attr = col->find(nodeAttrMapIt->first);
 
 			if (attr == col->end())
 			{
@@ -103,8 +103,8 @@ namespace gq
 				// There is already an entry for the attribute name, but that just means a map exists. Have to
 				// check if values exists and if so, append, if not, insert/create the key and vector collection.
 
-				auto& anyValueMatch = attr->second.find(SpecialTraits::GetAnyValue());
-				auto& exactValueMatch = attr->second.find(nodeAttrMapIt->second);
+				const auto& anyValueMatch = attr->second.find(SpecialTraits::GetAnyValue());
+				const auto& exactValueMatch = attr->second.find(nodeAttrMapIt->second);
 
 				// We need to check to make sure that the node doesn't already exist in the collection. This is because
 				// of the way that we split up space and hyphen delimited lists in attribute values. For example, when
@@ -169,7 +169,7 @@ namespace gq
 	const std::vector< const Node* >* TreeMap::Get(boost::string_ref scope, boost::string_ref attribute, boost::string_ref attributeValue) const
 	{
 		// First, jump the the correct scope to begin matching from.
-		auto& atScope = m_scopedAttributes.find(scope);
+		const auto& atScope = m_scopedAttributes.find(scope);
 
 		#ifndef NDEBUG
 			assert(atScope != m_scopedAttributes.end() && u8"In TreeMap::Get(boost::string_ref, boost::string_ref, boost::string_ref) - The supplied scope does not exist. This error is impossible unless a user is directly and incorrectly calling this method, or if this class and its required mechanisms are fundamentally broken.");
@@ -189,11 +189,11 @@ namespace gq
 		#endif
 
 		// Search for the attribute name at this scope		
-		auto& byAttrName = atScope->second.find(attribute);
+		const auto& byAttrName = atScope->second.find(attribute);
 		if (byAttrName != atScope->second.end())
 		{
 			// If we found matches to the attribute, search for the exact value
-			auto& byAttrValue = byAttrName->second.find(attributeValue);
+			const auto& byAttrValue = byAttrName->second.find(attributeValue);
 						
 			if (byAttrValue != byAttrName->second.end())
 			{

--- a/src/UnarySelector.cpp
+++ b/src/UnarySelector.cpp
@@ -65,7 +65,7 @@ namespace gq
 		// If it's not a not selector, and there's no children, we can't do a child or descendant match
 		if (m_operator != SelectorOperator::Not && node->GetNumChildren() == 0)
 		{
-			return false;
+			return nullptr;
 		}
 
 		switch (m_operator)
@@ -80,7 +80,7 @@ namespace gq
 				}
 				else
 				{
-					result;
+					return result;
 				}
 			}
 			break;
@@ -95,7 +95,7 @@ namespace gq
 					return MatchResult(node);
 				}
 
-				return false;
+				return nullptr;
 			}
 			break;
 
@@ -118,13 +118,13 @@ namespace gq
 					}
 				}
 
-				return false;				
+				return nullptr;				
 			}
 			break;	
 		}
 
 		// Just to shut up the compiler.
-		return false;
+		return nullptr;
 	}
 
 	const Selector::MatchResult UnarySelector::HasDescendantMatch(const Node* node) const
@@ -147,7 +147,7 @@ namespace gq
 			}
 		}
 
-		return false;
+		return nullptr;
 	}
 
 } /* namespace gq */


### PR DESCRIPTION
I added this library to a linux project of mine and thought I might as well contribute these fixes back.

Things I fixed (in addition to the cmake build script):

There were a lot of MatchResults that were constructed with falses
I had to replace those with nullptrs

There was also one unused value that I thought was probably meant to be
returned

And also there were illegal references taken, some of which I changed to
const references and some to plain values (iterators)

I also reordered a few initializations which were in the wrong order.

And I fixed the std::locale name on linux