### PR TITLE
Add CMake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,23 @@
 # This is meant to be used within a cmake project
 cmake_minimum_required(VERSION 3.0)
 
+set(PROJECT_VERSION 1.0.0)
+
 if(UNIX)
   
   # C++14
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wl,--no-undefined -Wl,--no-allow-shlib-undefined")
   
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/GQ.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/GQ.pc" @ONLY
+  )
+
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/GQ.pc"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig"
+  )
+
 endif(UNIX)
 
 find_package(PkgConfig REQUIRED)
@@ -14,6 +26,8 @@ pkg_check_modules(GUMBO REQUIRED gumbo)
 
 include_directories(${GUMBO_INCLUDE_DIRS})
 link_directories(${GUMBO_LIBRARY_DIRS})
+
+file(GLOB_RECURSE HEADERS "src/*.hpp")
 
 add_library(GQ SHARED
 
@@ -50,6 +64,10 @@ add_library(GQ SHARED
 
 target_link_libraries(GQ ${GUMBO_LIBRARIES})
 
+set_target_properties(GQ PROPERTIES PUBLIC_HEADER "${HEADERS}")
 
-
-  
+install(
+  TARGETS GQ
+  LIBRARY DESTINATION lib
+  PUBLIC_HEADER DESTINATION include/GQ
+)

--- a/GQ.pc.in
+++ b/GQ.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+sharedlibdir=${libdir}
+includedir=${prefix}/include/GQ
+
+Name: GQ
+Description: A C++ CSS Selector Engine for Gumbo Parser
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -lGQ
+Cflags: -I${includedir}


### PR DESCRIPTION
I've added a CMake install target which also generates a pkg-config meta data file. The library name is kept as GQ, but it looks like there are other libraries out there with the same name - a brief search didn't show any `gq.pc`'s which they would clash with.

libgq for gconf uses gq-gconf.pc, [here](https://github.com/openwebos/qt/blob/master/src/3rdparty/libgq/gconf/gq-gconf.pc.in). It might be good to add a prefix or suffix, but that's up to you.

It's not directly related, but I added a package to Arch's AUR for your project, available [here](https://aur.archlinux.org/packages/gumbo-gq-git/). This patch is currently applied before installation.

Thanks.

**Edit:** I've moved the pkg-config file to within the UNIX specific block, but I'm unable to test the generic install section on anything other than Linux.